### PR TITLE
Utilities As Macros

### DIFF
--- a/rust/ardutils/src/command/macros.rs
+++ b/rust/ardutils/src/command/macros.rs
@@ -1,0 +1,75 @@
+macro_rules! command_utils {
+    ($($dialect:ident)::+) => {
+        impl $crate::command::Command<$($dialect)::*::MavMessage, $($dialect)::*::COMMAND_ACK_DATA> for $($dialect)::*::COMMAND_INT_DATA {
+            fn command<C>(&self, connection: std::sync::Arc<C>) -> Result<usize, $crate::connection::MavlinkConnectionError>
+            where
+                C: $crate::connection::MavlinkConnection<$($dialect)::*::MavMessage> + std::fmt::Debug + Send + Sync,
+            {
+                connection.send(&$($dialect)::*::MavMessage::COMMAND_INT(self.clone()))
+            }
+
+            fn command_monitor<C>(
+                &self,
+                connection: std::sync::Arc<C>,
+                timeout: Option<std::time::Duration>,
+            ) -> tokio::sync::watch::Receiver<Option<$($dialect)::*::COMMAND_ACK_DATA>>
+            where
+                C: $crate::connection::MavlinkConnection<$($dialect)::*::MavMessage> + Debug + Send + Sync,
+            {
+                let (tx, rx) = tokio::sync::watch::channel(None);
+
+                connection.clone().monitor(timeout, move |msg| {
+                    if let $($dialect)::*::MavMessage::COMMAND_ACK(data) = msg {
+                        tx.send(Some(data.clone())).unwrap();
+                        if !matches!(data.result, $($dialect)::*::MavResult::MAV_RESULT_IN_PROGRESS) {
+                            return None;
+                        }
+                    }
+                    Some(())
+                });
+
+                connection
+                    .send(&$($dialect)::*::MavMessage::COMMAND_INT(self.clone()))
+                    .expect("Could not send message across mavlink connection -- must have closed");
+
+                rx
+            }
+        }
+
+        impl $crate::command::Command<$($dialect)::*::MavMessage, $($dialect)::*::COMMAND_ACK_DATA> for $($dialect)::*::COMMAND_LONG_DATA {
+            fn command<C>(&self, connection: std::sync::Arc<C>) -> Result<usize, $crate::connection::MavlinkConnectionError>
+            where
+                C: $crate::connection::MavlinkConnection<$($dialect)::*::MavMessage> + std::fmt::Debug + Send + Sync,
+            {
+                connection.send(&$($dialect)::*::MavMessage::COMMAND_LONG(self.clone()))
+            }
+
+            fn command_monitor<C>(
+                &self,
+                connection: std::sync::Arc<C>,
+                timeout: Option<std::time::Duration>,
+            ) -> tokio::sync::watch::Receiver<Option<$($dialect)::*::COMMAND_ACK_DATA>>
+            where
+                C: $crate::connection::MavlinkConnection<$($dialect)::*::MavMessage> + Debug + Send + Sync,
+            {
+                let (tx, rx) = tokio::sync::watch::channel(None);
+
+                connection.clone().monitor(timeout, move |msg| {
+                    if let $($dialect)::*::MavMessage::COMMAND_ACK(data) = msg {
+                        tx.send(Some(data.clone())).unwrap();
+                        if !matches!(data.result, $($dialect)::*::MavResult::MAV_RESULT_IN_PROGRESS) {
+                            return None;
+                        }
+                    }
+                    Some(())
+                });
+
+                connection
+                    .send(&$($dialect)::*::MavMessage::COMMAND_LONG(self.clone()))
+                    .expect("Could not send message across mavlink connection -- must have closed");
+
+                rx
+            }
+        }
+    };
+}

--- a/rust/ardutils/src/command/mod.rs
+++ b/rust/ardutils/src/command/mod.rs
@@ -1,306 +1,40 @@
 use std::{fmt::Debug, sync::Arc};
 
-use mavlink::ardupilotmega::{MavMessage, MavResult, COMMAND_ACK_DATA};
-
 use crate::connection::{MavlinkConnection, MavlinkConnectionError};
 
-pub trait Command {
+#[macro_use]
+mod macros;
+
+pub trait Command<Msg, Ack>
+where
+    Msg: Send + Sync
+{
     fn command<C>(&self, connection: Arc<C>) -> Result<usize, MavlinkConnectionError>
     where
-        C: MavlinkConnection + Debug + Send + Sync;
+        C: MavlinkConnection<Msg> + Debug + Send + Sync;
 
     fn command_monitor<C>(
         &self,
         connection: Arc<C>,
         timeout: Option<std::time::Duration>,
-    ) -> tokio::sync::watch::Receiver<Option<COMMAND_ACK_DATA>>
+    ) -> tokio::sync::watch::Receiver<Option<Ack>>
     where
-        C: MavlinkConnection + Debug + Send + Sync;
+        C: MavlinkConnection<Msg> + Debug + Send + Sync;
 
     fn command_retry<C>(
         &self,
         _connection: Arc<C>,
         _timeout: std::time::Duration,
         _retry_max: u8,
-    ) -> Result<Option<COMMAND_ACK_DATA>, MavlinkConnectionError>
+    ) -> Result<Option<Ack>, MavlinkConnectionError>
     where
-        C: MavlinkConnection + Debug + Send + Sync,
+        C: MavlinkConnection<Msg> + Debug + Send + Sync,
     {
         unimplemented!("Command Retries are not implemented")
     }
 }
 
-impl Command for mavlink::ardupilotmega::COMMAND_INT_DATA {
-    fn command<C>(&self, connection: Arc<C>) -> Result<usize, MavlinkConnectionError>
-    where
-        C: MavlinkConnection + Debug + Send + Sync,
-    {
-        connection.send(&MavMessage::COMMAND_INT(self.clone()))
-    }
-
-    fn command_monitor<C>(
-        &self,
-        connection: Arc<C>,
-        timeout: Option<std::time::Duration>,
-    ) -> tokio::sync::watch::Receiver<Option<COMMAND_ACK_DATA>>
-    where
-        C: MavlinkConnection + Debug + Send + Sync,
-    {
-        let (tx, rx) = tokio::sync::watch::channel(None);
-
-        connection.clone().monitor(timeout, move |msg| {
-            if let MavMessage::COMMAND_ACK(data) = msg {
-                tx.send(Some(data.clone())).unwrap();
-                if !matches!(data.result, MavResult::MAV_RESULT_IN_PROGRESS) {
-                    return None;
-                }
-            }
-            Some(())
-        });
-
-        connection
-            .send(&MavMessage::COMMAND_INT(self.clone()))
-            .expect("Could not send message across mavlink connection -- must have closed");
-
-        rx
-    }
-}
-
-impl Command for mavlink::ardupilotmega::COMMAND_LONG_DATA {
-    fn command<C>(&self, connection: Arc<C>) -> Result<usize, MavlinkConnectionError>
-    where
-        C: MavlinkConnection + Debug + Send + Sync,
-    {
-        connection.send(&MavMessage::COMMAND_LONG(self.clone()))
-    }
-
-    fn command_monitor<C>(
-        &self,
-        connection: Arc<C>,
-        timeout: Option<std::time::Duration>,
-    ) -> tokio::sync::watch::Receiver<Option<COMMAND_ACK_DATA>>
-    where
-        C: MavlinkConnection + Debug + Send + Sync,
-    {
-        let (tx, rx) = tokio::sync::watch::channel(None);
-
-        connection.clone().monitor(timeout, move |msg| {
-            if let MavMessage::COMMAND_ACK(data) = msg {
-                tx.send(Some(data.clone())).unwrap();
-                if !matches!(data.result, MavResult::MAV_RESULT_IN_PROGRESS) {
-                    return None;
-                }
-            }
-            Some(())
-        });
-
-        connection
-            .send(&MavMessage::COMMAND_LONG(self.clone()))
-            .expect("Could not send message across mavlink connection -- must have closed");
-
-        rx
-    }
-}
+command_utils!(mavlink::ardupilotmega);
 
 #[cfg(test)]
-mod test {
-    use crate::command::Command;
-    use std::sync::Arc;
-
-    use mavlink::ardupilotmega::{
-        MavMessage, MavResult, COMMAND_ACK_DATA, COMMAND_INT_DATA, COMMAND_LONG_DATA,
-    };
-
-    use crate::connection::test::*;
-
-    #[tokio::test]
-    async fn command_int() {
-        let connection: Arc<Box<TestMavConnection>> = Default::default();
-
-        start_heartbeats(connection.clone());
-
-        COMMAND_INT_DATA::default()
-            .command(connection.clone())
-            .unwrap();
-
-        assert!(matches!(
-            connection.last_sent().unwrap(),
-            MavMessage::COMMAND_INT(COMMAND_INT_DATA { .. })
-        ));
-    }
-
-    #[tokio::test]
-    async fn command_long() {
-        let connection: Arc<Box<TestMavConnection>> = Default::default();
-
-        start_heartbeats(connection.clone());
-
-        COMMAND_LONG_DATA::default()
-            .command(connection.clone())
-            .unwrap();
-
-        assert!(matches!(
-            connection.last_sent().unwrap(),
-            MavMessage::COMMAND_LONG(COMMAND_LONG_DATA { .. })
-        ));
-    }
-
-    #[tokio::test]
-    async fn monitor_int() {
-        let connection: Arc<Box<TestMavConnection>> = Default::default();
-
-        let mut rx = COMMAND_INT_DATA::default()
-            .command_monitor(connection.clone(), Some(std::time::Duration::from_secs(1)));
-
-        connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
-            result: MavResult::MAV_RESULT_ACCEPTED,
-            ..Default::default()
-        }));
-
-        tokio::time::timeout(std::time::Duration::from_secs(1), async move {
-            while rx.changed().await.is_ok() {
-                assert!(matches!(
-                    rx.borrow().clone().unwrap(),
-                    COMMAND_ACK_DATA {
-                        result: MavResult::MAV_RESULT_ACCEPTED,
-
-                        ..
-                    }
-                ));
-            }
-        })
-        .await
-        .unwrap();
-    }
-
-    #[tokio::test]
-    async fn monitor_long() {
-        let connection: Arc<Box<TestMavConnection>> = Default::default();
-
-        let mut rx = COMMAND_LONG_DATA::default()
-            .command_monitor(connection.clone(), Some(std::time::Duration::from_secs(1)));
-
-        connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
-            result: MavResult::MAV_RESULT_ACCEPTED,
-            ..Default::default()
-        }));
-
-        tokio::time::timeout(std::time::Duration::from_secs(1), async move {
-            while rx.changed().await.is_ok() {
-                assert!(matches!(
-                    rx.borrow().clone().unwrap(),
-                    COMMAND_ACK_DATA {
-                        result: MavResult::MAV_RESULT_ACCEPTED,
-
-                        ..
-                    }
-                ));
-            }
-        })
-        .await
-        .unwrap();
-    }
-
-    #[tokio::test]
-    async fn monitor_int_failed() {
-        let connection: Arc<Box<TestMavConnection>> = Default::default();
-
-        let mut rx = COMMAND_INT_DATA::default().command_monitor(connection.clone(), None);
-
-        connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
-            result: MavResult::MAV_RESULT_FAILED,
-            ..Default::default()
-        }));
-
-        tokio::time::timeout(std::time::Duration::from_secs(3), async move {
-            while rx.changed().await.is_ok() {
-                assert!(matches!(
-                    rx.borrow_and_update().clone().unwrap(),
-                    COMMAND_ACK_DATA {
-                        result: MavResult::MAV_RESULT_FAILED,
-
-                        ..
-                    }
-                ));
-            }
-            // This tells us that the transmitter has been dropped -- and the monitor is over.
-            assert!(rx.has_changed().is_err());
-        })
-        .await
-        .unwrap();
-    }
-
-    #[tokio::test]
-    async fn monitor_long_failed() {
-        let connection: Arc<Box<TestMavConnection>> = Default::default();
-
-        let mut rx = COMMAND_LONG_DATA::default().command_monitor(connection.clone(), None);
-
-        connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
-            result: MavResult::MAV_RESULT_FAILED,
-            ..Default::default()
-        }));
-
-        tokio::time::timeout(std::time::Duration::from_secs(3), async move {
-            while rx.changed().await.is_ok() {
-                assert!(matches!(
-                    rx.borrow_and_update().clone().unwrap(),
-                    COMMAND_ACK_DATA {
-                        result: MavResult::MAV_RESULT_FAILED,
-                        ..
-                    }
-                ));
-            }
-            // This tells us that the transmitter has been dropped -- and the monitor is over.
-            assert!(rx.has_changed().is_err());
-        })
-        .await
-        .unwrap();
-    }
-
-    #[tokio::test]
-    async fn monitor_long_progress() {
-        let connection: Arc<Box<TestMavConnection>> = Default::default();
-
-        let mut rx = COMMAND_INT_DATA::default().command_monitor(connection.clone(), None);
-
-        connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
-            result: MavResult::MAV_RESULT_IN_PROGRESS,
-            ..Default::default()
-        }));
-
-        tokio::time::timeout(std::time::Duration::from_secs(3), async move {
-            rx.changed().await.unwrap();
-
-            assert!(matches!(
-                rx.borrow().clone().unwrap(),
-                COMMAND_ACK_DATA {
-                    result: MavResult::MAV_RESULT_IN_PROGRESS,
-
-                    ..
-                }
-            ));
-            // This tells us that the transmitter is still open, and the watch is still happening.
-            assert!(rx.has_changed().is_ok());
-
-            connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
-                result: MavResult::MAV_RESULT_ACCEPTED,
-                ..Default::default()
-            }));
-
-            rx.changed().await.unwrap();
-            assert!(matches!(
-                rx.borrow().clone().unwrap(),
-                COMMAND_ACK_DATA {
-                    result: MavResult::MAV_RESULT_ACCEPTED,
-
-                    ..
-                }
-            ));
-            // This tells us that the transmitter is has been dropped, and the watch is over.
-            assert!(rx.has_changed().is_err());
-        })
-        .await
-        .unwrap();
-    }
-}
+mod test;

--- a/rust/ardutils/src/command/test.rs
+++ b/rust/ardutils/src/command/test.rs
@@ -1,0 +1,203 @@
+use crate::command::Command;
+use std::sync::Arc;
+
+use mavlink::ardupilotmega::{
+    MavMessage, MavResult, COMMAND_ACK_DATA, COMMAND_INT_DATA, COMMAND_LONG_DATA,
+};
+
+use crate::connection::test::*;
+
+#[tokio::test]
+async fn command_int() {
+    let connection: Arc<Box<TestMavConnection>> = Default::default();
+
+    start_heartbeats(connection.clone());
+
+    COMMAND_INT_DATA::default()
+        .command(connection.clone())
+        .unwrap();
+
+    assert!(matches!(
+        connection.last_sent().unwrap(),
+        MavMessage::COMMAND_INT(COMMAND_INT_DATA { .. })
+    ));
+}
+
+#[tokio::test]
+async fn command_long() {
+    let connection: Arc<Box<TestMavConnection>> = Default::default();
+
+    start_heartbeats(connection.clone());
+
+    COMMAND_LONG_DATA::default()
+        .command(connection.clone())
+        .unwrap();
+
+    assert!(matches!(
+        connection.last_sent().unwrap(),
+        MavMessage::COMMAND_LONG(COMMAND_LONG_DATA { .. })
+    ));
+}
+
+#[tokio::test]
+async fn monitor_int() {
+    let connection: Arc<Box<TestMavConnection>> = Default::default();
+
+    let mut rx = COMMAND_INT_DATA::default()
+        .command_monitor(connection.clone(), Some(std::time::Duration::from_secs(1)));
+
+    connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
+        result: MavResult::MAV_RESULT_ACCEPTED,
+        ..Default::default()
+    }));
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async move {
+        while rx.changed().await.is_ok() {
+            assert!(matches!(
+                rx.borrow().clone().unwrap(),
+                COMMAND_ACK_DATA {
+                    result: MavResult::MAV_RESULT_ACCEPTED,
+
+                    ..
+                }
+            ));
+        }
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn monitor_long() {
+    let connection: Arc<Box<TestMavConnection>> = Default::default();
+
+    let mut rx = COMMAND_LONG_DATA::default()
+        .command_monitor(connection.clone(), Some(std::time::Duration::from_secs(1)));
+
+    connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
+        result: MavResult::MAV_RESULT_ACCEPTED,
+        ..Default::default()
+    }));
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async move {
+        while rx.changed().await.is_ok() {
+            assert!(matches!(
+                rx.borrow().clone().unwrap(),
+                COMMAND_ACK_DATA {
+                    result: MavResult::MAV_RESULT_ACCEPTED,
+
+                    ..
+                }
+            ));
+        }
+
+        // This tells us that the transmitter has been dropped -- and the monitor is over.
+        assert!(rx.has_changed().is_err());
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn monitor_int_failed() {
+    let connection: Arc<Box<TestMavConnection>> = Default::default();
+
+    let mut rx = COMMAND_INT_DATA::default().command_monitor(connection.clone(), None);
+
+    connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
+        result: MavResult::MAV_RESULT_FAILED,
+        ..Default::default()
+    }));
+
+    tokio::time::timeout(std::time::Duration::from_secs(3), async move {
+        while rx.changed().await.is_ok() {
+            assert!(matches!(
+                rx.borrow_and_update().clone().unwrap(),
+                COMMAND_ACK_DATA {
+                    result: MavResult::MAV_RESULT_FAILED,
+
+                    ..
+                }
+            ));
+        }
+        // This tells us that the transmitter has been dropped -- and the monitor is over.
+        assert!(rx.has_changed().is_err());
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn monitor_long_failed() {
+    let connection: Arc<Box<TestMavConnection>> = Default::default();
+
+    let mut rx = COMMAND_LONG_DATA::default().command_monitor(connection.clone(), None);
+
+    connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
+        result: MavResult::MAV_RESULT_FAILED,
+        ..Default::default()
+    }));
+
+    tokio::time::timeout(std::time::Duration::from_secs(3), async move {
+        while rx.changed().await.is_ok() {
+            assert!(matches!(
+                rx.borrow_and_update().clone().unwrap(),
+                COMMAND_ACK_DATA {
+                    result: MavResult::MAV_RESULT_FAILED,
+                    ..
+                }
+            ));
+        }
+        // This tells us that the transmitter has been dropped -- and the monitor is over.
+        assert!(rx.has_changed().is_err());
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn monitor_long_progress() {
+    let connection: Arc<Box<TestMavConnection>> = Default::default();
+
+    let mut rx = COMMAND_INT_DATA::default().command_monitor(connection.clone(), None);
+
+    connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
+        result: MavResult::MAV_RESULT_IN_PROGRESS,
+        ..Default::default()
+    }));
+
+    tokio::time::timeout(std::time::Duration::from_secs(3), async move {
+        rx.changed().await.unwrap();
+
+        assert!(matches!(
+            rx.borrow().clone().unwrap(),
+            COMMAND_ACK_DATA {
+                result: MavResult::MAV_RESULT_IN_PROGRESS,
+
+                ..
+            }
+        ));
+        
+        // This tells us that the transmitter is still open, and the watch is still happening.
+        assert!(rx.has_changed().is_ok());
+
+        connection.inject_msg(MavMessage::COMMAND_ACK(COMMAND_ACK_DATA {
+            result: MavResult::MAV_RESULT_ACCEPTED,
+            ..Default::default()
+        }));
+
+        rx.changed().await.unwrap();
+        assert!(matches!(
+            rx.borrow().clone().unwrap(),
+            COMMAND_ACK_DATA {
+                result: MavResult::MAV_RESULT_ACCEPTED,
+
+                ..
+            }
+        ));
+        // This tells us that the transmitter is has been dropped, and the watch is over.
+        assert!(rx.has_changed().is_err());
+    })
+    .await
+    .unwrap();
+}

--- a/rust/ardutils/src/mission/upload.rs
+++ b/rust/ardutils/src/mission/upload.rs
@@ -14,7 +14,10 @@ pub struct Options {
 }
 
 #[async_trait::async_trait]
-pub trait MissionUpload {
+pub trait MissionUpload<Msg>
+where
+    Msg: Send + Sync,
+{
     // If successful, returns the number of mission items uploaded.
     // Otherwise, returns the error.
     async fn upload_mission<C>(
@@ -23,7 +26,7 @@ pub trait MissionUpload {
         options: Options,
     ) -> Result<u16, MissionUploadError>
     where
-        C: MavlinkConnection + Debug + Send + Sync;
+        C: MavlinkConnection<Msg> + Debug + Send + Sync;
 }
 
 pub enum MissionUploadError {
@@ -33,7 +36,7 @@ pub enum MissionUploadError {
 }
 
 #[async_trait::async_trait]
-impl MissionUpload for Vec<MISSION_ITEM_INT_DATA> {
+impl MissionUpload<mavlink::ardupilotmega::MavMessage> for Vec<MISSION_ITEM_INT_DATA> {
     #[instrument]
     async fn upload_mission<C>(
         self,
@@ -41,7 +44,7 @@ impl MissionUpload for Vec<MISSION_ITEM_INT_DATA> {
         options: Options,
     ) -> Result<u16, MissionUploadError>
     where
-        C: MavlinkConnection + Debug + Send + Sync,
+        C: MavlinkConnection<mavlink::ardupilotmega::MavMessage> + Debug + Send + Sync,
     {
         let count = self.len() as u16;
 

--- a/rust/ardutils/src/mode.rs
+++ b/rust/ardutils/src/mode.rs
@@ -5,17 +5,20 @@ use mavlink::ardupilotmega;
 use crate::connection::{FilterRes, MavlinkConnection, MavlinkConnectionError};
 
 #[async_trait::async_trait]
-pub trait ChangeMode {
+pub trait ChangeMode<Msg>
+where
+    Msg: Send + Sync,
+{
     async fn change_mode<C>(self, connection: Arc<C>) -> Result<(), MavlinkConnectionError>
     where
-        C: MavlinkConnection + Send + Sync;
+        C: MavlinkConnection<Msg> + Send + Sync;
 }
 
 #[async_trait::async_trait]
-impl ChangeMode for ardupilotmega::PlaneMode {
+impl ChangeMode<mavlink::ardupilotmega::MavMessage> for ardupilotmega::PlaneMode {
     async fn change_mode<C>(self, connection: Arc<C>) -> Result<(), MavlinkConnectionError>
     where
-        C: MavlinkConnection + Send + Sync,
+        C: MavlinkConnection<mavlink::ardupilotmega::MavMessage> + Send + Sync,
     {
         connection
             .clone()


### PR DESCRIPTION
This enables creating different utils (with the same functionality, but for different dialects (assuming they were all made with the same mavlink version).